### PR TITLE
Disable autocast if MPS is available, to force it to work

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -946,7 +946,9 @@ class CogVideoSampler:
             padding = torch.zeros((negative.shape[0], target_length - negative.shape[1], negative.shape[2]), device=negative.device)
             negative = torch.cat((negative, padding), dim=1)
 
-        autocastcondition = not pipeline["onediff"]
+        # Note: if we're on MPS return False, otherwise check for onediff as normal
+        # TODO: Torch 2.5+ is supposed to add AMP support for MPS ... not available currently.
+        autocastcondition = not pipeline["onediff"] if not torch.backends.mps.is_available() else False
         autocast_context = torch.autocast(mm.get_autocast_device(device)) if autocastcondition else nullcontext()
         with autocast_context:
             latents = pipeline["pipe"](
@@ -1213,7 +1215,9 @@ class CogVideoXFunVid2VidSampler:
 
         generator= torch.Generator(device).manual_seed(seed)
 
-        autocastcondition = not pipeline["onediff"]
+        # Note: if we're on MPS return False, otherwise check for onediff as normal
+        # TODO: Torch 2.5+ is supposed to add AMP support for MPS ... not available currently.
+        autocastcondition = not pipeline["onediff"] if not torch.backends.mps.is_available() else False
         autocast_context = torch.autocast(mm.get_autocast_device(device)) if autocastcondition else nullcontext()
         with autocast_context:
             video_length = int((video_length - 1) // pipe.vae.config.temporal_compression_ratio * pipe.vae.config.temporal_compression_ratio) + 1 if video_length != 1 else 1
@@ -1460,7 +1464,9 @@ class CogVideoXFunControlSampler:
 
         generator=torch.Generator(torch.device("cpu")).manual_seed(seed)
 
-        autocastcondition = not pipeline["onediff"]
+        # Note: if we're on MPS return False, otherwise check for onediff as normal
+        # TODO: Torch 2.5+ is supposed to add AMP support for MPS ... not available currently.
+        autocastcondition = not pipeline["onediff"] if not torch.backends.mps.is_available() else False
         autocast_context = torch.autocast(mm.get_autocast_device(device)) if autocastcondition else nullcontext()
         with autocast_context:
 

--- a/nodes.py
+++ b/nodes.py
@@ -1116,7 +1116,9 @@ class CogVideoXFunSampler:
 
         generator= torch.Generator(device="cpu").manual_seed(seed)
 
-        autocastcondition = not pipeline["onediff"]
+        # Note: if we're on MPS return False, otherwise check for onediff as normal
+        # TODO: Torch 2.5+ is supposed to add AMP support for MPS ... not available currently.
+        autocastcondition = not pipeline["onediff"] if not torch.backends.mps.is_available() else False 
         autocast_context = torch.autocast(mm.get_autocast_device(device)) if autocastcondition else nullcontext()
         with autocast_context:
             video_length = int((video_length - 1) // pipe.vae.config.temporal_compression_ratio * pipe.vae.config.temporal_compression_ratio) + 1 if video_length != 1 else 1


### PR DESCRIPTION
AMP Autocast is not available on current pytorch, will be added in 2.5+ version and nightlies but those are buggy, for now just disable AMP if we're on MPS.

This is not a great fix, it's just a quick patch to get it running, spending more time fixing it doesn't make sense as technically AMP will work once the pytorch 2.5.0 comes out (if they ever fix the current bugs on apple silicon with other things)

You'll need to use fp32 which means its not memory efficient at all and insanely slow, the first video i did was ~40s/it for some reason ever since that run its 70-100+s/it so really not that useable, i might try to force things to fp16 but this patch at least proves it CAN run on Apple Silicon since some people were saying it couldn't.

I've tested this change on my Macbook M3 32gb and was able to generate a short video 

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/d3ed02f1-0130-40fc-9512-4dbc9eb45e6a">
